### PR TITLE
Publishing postdated post for Archive Tasks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ description: > # this means to ignore newlines until "baseurl:"
   Google search results) and in your feed.xml site description.
 url: "http://blog.dayboard.co" # the base hostname & protocol for your site
 permalink: /:title
+future: false
 
 twitter_username: dayboardco
 github_username:  jtcchan

--- a/_drafts/reshaping-of-teams-in-modern-workplace.html
+++ b/_drafts/reshaping-of-teams-in-modern-workplace.html
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: The Reshaping of Teams in the Modern Workplace
-date: 2016-09-09 09:14:00
+date: 2016-09-12 09:14:00
 categories: Productivity
 author: kat
 disqus_identifier:

--- a/_posts/2016-04-25-go-beyond-five-tasks-with-archive-tasks.html
+++ b/_posts/2016-04-25-go-beyond-five-tasks-with-archive-tasks.html
@@ -4,7 +4,7 @@ title: Go beyond five tasks with Archive Tasks
 date: 2016-04-25 10:20:00
 categories: Updates
 author: jenn
-disqus_identifier:
+disqus_identifier: 7
 teaser_src: "assets/images/product/archive-tasks.png"
 excerpt: We started Dayboard with the intention to keep your to-do list restricted to five tasks a day, but as we recieved feedback from you, our users, we know this need to change. I'm excited to share with you, Archive Tasks, where you're no longer limited to five a day.
 ---


### PR DESCRIPTION
Note: Just merging to gh-pages to get the post for archive tasks live. I've also added a config setting for future posts. So if we were to write posts and date it in the future, they shouldn't show up on the live blog even if we write them in _posts. 

At least I think that's what it's suppose to do when I read the Jekyll docs. 😛
